### PR TITLE
Add more examples for socketAddress

### DIFF
--- a/content/docs/configure/index.md
+++ b/content/docs/configure/index.md
@@ -51,7 +51,7 @@ Used to configure connection to the cncjs server, and controller serial port
 | `baudRate`              | {{< type "Integer" >}}                        | Serial connection baud rate                                                                                                   |
 | `port`                  | {{< type "String" >}}                         | Serial connection port                                                                                                        |
 | `controllerType`        | {{< type "Enum" >}}                           | Controller type. Allowed: [`Grbl`]                                                                                            |
-| `socketAddress`         | {{< type "String" >}}                         | URL for socket connection to cncjs. Usually `localhost`                                                                       |
+| `socketAddress`         | {{< type "String" >}}                         | URL for socket connection to cncjs. Usually `localhost`, the IP address or `YOUR_HOSTNAME`.local                              |
 | `socketPort`            | {{< type "Integer" >}}                        | Socket connection port for cncjs. Usually `80` or `8000`                                                                      |
 | `secure`                | {{< type "Boolean" >}}                        | If enabled, socket connections will be made over wss, and API requests over https. Default `false`                            |
 


### PR DESCRIPTION
This way, someone could use a different host (such as another mobile phone) to control the cnc.